### PR TITLE
Add workflow to automate Desarrollo to QA merges

### DIFF
--- a/.github/workflows/scheduled_merge.yml
+++ b/.github/workflows/scheduled_merge.yml
@@ -1,0 +1,29 @@
+name: Scheduled Merge Desarrollo to QA
+
+on:
+  schedule:
+    # Esto es para que se ejecute todos los días a las 23:00 UTC (que es a las 7pm et o sea 5pm costa rica)
+    - cron: "0 23 * * *"
+  workflow_dispatch:
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout QA branch
+        uses: actions/checkout@v4
+        with:
+          ref: QA
+
+      - name: Set up Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge Desarrollo into QA
+        run: |
+          git fetch origin Desarrollo
+          git merge origin/Desarrollo --no-ff -m "Automated merge from Desarrollo to QA"
+
+      - name: Push changes
+        run: git push origin QA


### PR DESCRIPTION
Introduces a GitHub Actions workflow that merges the Desarrollo branch into QA daily at 23:00 UTC and also allows manual triggering. This helps keep the QA branch up to date with the latest changes from Desarrollo automatically.