### PR TITLE
Update nullability constraints in SanitaryControl entity

### DIFF
--- a/src/main/java/com/project/demo/logic/entity/sanitary_control/SanitaryControl.java
+++ b/src/main/java/com/project/demo/logic/entity/sanitary_control/SanitaryControl.java
@@ -28,7 +28,7 @@ public class SanitaryControl {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "last_application_date", nullable = false)
+    @Column(name = "last_application_date")
     private LocalDate lastApplicationDate;
 
     /**
@@ -46,17 +46,17 @@ public class SanitaryControl {
     private boolean validityStatus;
 
 
-    @Column(name = "product_used", nullable = false)
+    @Column(name = "product_used")
     private String productUsed;
 
     private String observations;
 
     @ManyToOne
-    @JoinColumn(name = "sanitary_control_type_id", nullable = false)
+    @JoinColumn(name = "sanitary_control_type_id")
     private SanitaryControlType sanitaryControlType;
 
     @ManyToOne
-    @JoinColumn(name = "sanitary_control_response_id")
+    @JoinColumn(name = "sanitary_control_response_id", nullable = false)
     private SanitaryControlResponse sanitaryControlResponse;
 
     @CreationTimestamp


### PR DESCRIPTION
This pull request modifies the `SanitaryControl` entity in the file `SanitaryControl.java` to adjust database column constraints. The changes primarily involve altering the `nullable` property for several fields to better align with the application's requirements.

### Adjustments to database column constraints:

* Removed the `nullable = false` constraint from the `lastApplicationDate` field, making it optional in the database. (`[src/main/java/com/project/demo/logic/entity/sanitary_control/SanitaryControl.javaL31-R31](diffhunk://#diff-d6ba6b8fc41d7f2e38f34c39d89ebded01429c143d865d9027a8970a11e20196L31-R31)`)
* Removed the `nullable = false` constraint from the `productUsed` field, allowing it to be optional. (`[src/main/java/com/project/demo/logic/entity/sanitary_control/SanitaryControl.javaL49-R59](diffhunk://#diff-d6ba6b8fc41d7f2e38f34c39d89ebded01429c143d865d9027a8970a11e20196L49-R59)`)
* Removed the `nullable = false` constraint from the `sanitaryControlType` field, making it optional. (`[src/main/java/com/project/demo/logic/entity/sanitary_control/SanitaryControl.javaL49-R59](diffhunk://#diff-d6ba6b8fc41d7f2e38f34c39d89ebded01429c143d865d9027a8970a11e20196L49-R59)`)
* Added the `nullable = false` constraint to the `sanitaryControlResponse` field, ensuring it is now required. (`[src/main/java/com/project/demo/logic/entity/sanitary_control/SanitaryControl.javaL49-R59](diffhunk://#diff-d6ba6b8fc41d7f2e38f34c39d89ebded01429c143d865d9027a8970a11e20196L49-R59)`)Adjusted @Column and @JoinColumn annotations in SanitaryControl.java to change which fields are nullable. This change relaxes constraints on lastApplicationDate, productUsed, and sanitaryControlType, while making sanitaryControlResponse non-nullable.