### PR TITLE
Add AnimalType seeder and REST controller

### DIFF
--- a/src/main/java/com/project/demo/logic/entity/animal/Animal.java
+++ b/src/main/java/com/project/demo/logic/entity/animal/Animal.java
@@ -66,7 +66,7 @@ public class Animal {
     @Column(name = "birth_date", nullable = false)
     private LocalDate birthDate;
 
-      @ManyToOne
+    @ManyToOne
     @JoinColumn(name = "animal_type_id", nullable = false)
     private AnimalType animalType;
 

--- a/src/main/java/com/project/demo/logic/seeds/AnimalTypeSeeder.java
+++ b/src/main/java/com/project/demo/logic/seeds/AnimalTypeSeeder.java
@@ -1,0 +1,58 @@
+package com.project.demo.logic.seeds;
+
+import com.project.demo.logic.constants.general.GeneralConstants;
+import com.project.demo.logic.entity.animal_type.AnimalType;
+import com.project.demo.logic.entity.animal_type.AnimalTypeEnum;
+import com.project.demo.logic.entity.animal_type.AnimalTypeRepository;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Seeder class to initialize animal types in the database.
+ * <p>
+ * This class listens for the application context refresh event and populates the database
+ * with predefined animal types if they do not already exist.
+ * @author dgutierrez
+ */
+@Order(GeneralConstants.ANIMAL_TYPE_SEEDER_ORDER)
+@Component
+public class AnimalTypeSeeder implements ApplicationListener<ContextRefreshedEvent> {
+    private final AnimalTypeRepository animalTypeRepository;
+
+    private final Logger logger = LoggerFactory.getLogger(AnimalTypeSeeder.class);
+
+    public AnimalTypeSeeder(AnimalTypeRepository animalTypeRepository) {
+        this.animalTypeRepository = animalTypeRepository;
+    }
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
+        this.loadAnimalTypes();
+    }
+
+    private void loadAnimalTypes() {
+        if (animalTypeRepository.count() > 0) {
+            logger.info("AnimalTypeSeeder: Animal types already exist, skipping seeding.");
+            return;
+        }
+
+        for (AnimalTypeEnum animalTypeEnum : AnimalTypeEnum.values()) {
+            if (animalTypeRepository.findByName(animalTypeEnum.getName()).isEmpty()) {
+                var animalType = AnimalType.builder()
+                        .name(animalTypeEnum.getName())
+                        .description(animalTypeEnum.getDescription())
+                        .build();
+
+                animalTypeRepository.save(animalType);
+                logger.info("AnimalTypeSeeder: Animal type '{}' created successfully.", animalTypeEnum.getName());
+            }
+        }
+
+        logger.info("AnimalTypeSeeder: Animal types seeded successfully.");
+    }
+}

--- a/src/main/java/com/project/demo/logic/seeds/CommunityAnimalSeeder.java
+++ b/src/main/java/com/project/demo/logic/seeds/CommunityAnimalSeeder.java
@@ -1,5 +1,6 @@
 package com.project.demo.logic.seeds;
 import com.project.demo.logic.constants.general.GeneralConstants;
+import com.project.demo.logic.entity.animal_type.AnimalTypeRepository;
 import com.project.demo.logic.entity.community_animal.CommunityAnimal;
 import com.project.demo.logic.entity.community_animal.CommunityAnimalRepository;
 import com.project.demo.logic.entity.race.Race;
@@ -25,18 +26,20 @@ public class CommunityAnimalSeeder implements CommandLineRunner {
     private final SpeciesRepository speciesRepository;
     private final RaceRepository raceRepository;
     private final SexRepository sexRepository;
+    private final AnimalTypeRepository animalTypeRepository;
 
     public CommunityAnimalSeeder(
             CommunityAnimalRepository communityAnimalRepository,
             UserRepository userRepository,
             SpeciesRepository speciesRepository,
             RaceRepository raceRepository,
-            SexRepository sexRepository) {
+            SexRepository sexRepository, AnimalTypeRepository animalTypeRepository) {
         this.communityAnimalRepository = communityAnimalRepository;
         this.userRepository = userRepository;
         this.speciesRepository = speciesRepository;
         this.raceRepository = raceRepository;
         this.sexRepository = sexRepository;
+        this.animalTypeRepository = animalTypeRepository;
     }
 
     @Override
@@ -47,8 +50,9 @@ public class CommunityAnimalSeeder implements CommandLineRunner {
         Species species = speciesRepository.findAll().stream().findFirst().orElse(null);
         Race race = raceRepository.findAll().stream().findFirst().orElse(null);
         Sex sex = sexRepository.findAll().stream().findFirst().orElse(null);
+        var animalType = animalTypeRepository.findAll().stream().findFirst().orElse(null);
 
-        if (user == null || species == null || race == null || sex == null ) return;
+        if (user == null || species == null || race == null || sex == null || animalType == null) return;
 
         CommunityAnimal animal = CommunityAnimal.builder()
                 .name("Maxwell")
@@ -60,6 +64,7 @@ public class CommunityAnimalSeeder implements CommandLineRunner {
                 .latitude(9.9)
                 .longitude(-84.0)
                 .user(user)
+                .animalType(animalType)
                 .build();
 
         communityAnimalRepository.save(animal);

--- a/src/main/java/com/project/demo/rest/animal_type/AnimalTypeRestController.java
+++ b/src/main/java/com/project/demo/rest/animal_type/AnimalTypeRestController.java
@@ -1,0 +1,74 @@
+package com.project.demo.rest.animal_type;
+
+import com.project.demo.common.PaginationUtils;
+import com.project.demo.logic.entity.animal_type.AnimalType;
+import com.project.demo.logic.entity.animal_type.AnimalTypeRepository;
+import com.project.demo.logic.entity.http.GlobalResponseHandler;
+import com.project.demo.logic.entity.http.Meta;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/animal-types")
+public class AnimalTypeRestController {
+
+    private static final Logger logger = LoggerFactory.getLogger(AnimalTypeRestController.class);
+
+    @Autowired
+    private AnimalTypeRepository animalTypeRepository;
+
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getAll(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            HttpServletRequest request) {
+
+        logger.info("Fetching all animal types");
+
+        Pageable pageable = PaginationUtils.buildPageable(page, size);
+        Page<AnimalType> animalTypePage = animalTypeRepository.findAll(pageable);
+
+        Meta meta = PaginationUtils.buildMeta(request, animalTypePage);
+
+        return new GlobalResponseHandler().handleResponse(
+                "Animal types retrieved successfully",
+                animalTypePage.getContent(),
+                HttpStatus.OK,
+                meta
+        );
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getById(@PathVariable Long id, HttpServletRequest request) {
+        logger.info("Fetching animal type with id: {}", id);
+        Optional<AnimalType> opt = animalTypeRepository.findById(id);
+
+        if (opt.isEmpty()) {
+            logger.warn("Animal type with id {} not found", id);
+            return new GlobalResponseHandler().handleResponse(
+                    "Animal type id " + id + " not found",
+                    HttpStatus.NOT_FOUND,
+                    request
+            );
+        }
+
+        return new GlobalResponseHandler().handleResponse(
+                "Animal type retrieved successfully",
+                opt.get(),
+                HttpStatus.OK,
+                request
+        );
+    }
+}


### PR DESCRIPTION
This pull request introduces functionality for managing animal types in the system, including database seeding, integration with other seeders, and a REST API for fetching animal type data. The changes are grouped into three main themes: database seeding, integration with existing seeders, and REST API implementation.

### Database Seeding:
* Added `AnimalTypeSeeder` class to seed predefined animal types into the database during application startup. The seeder ensures no duplicate entries are created and logs the seeding process. (`src/main/java/com/project/demo/logic/seeds/AnimalTypeSeeder.java`)

### Integration with Existing Seeders:
* Updated `CommunityAnimalSeeder` to include `AnimalTypeRepository` as a dependency, ensuring that community animals are associated with an `AnimalType` during seeding. (`src/main/java/com/project/demo/logic/seeds/CommunityAnimalSeeder.java`) [[1]](diffhunk://#diff-533b1a169348757840481dba5d0410305f939e43a62c534cf2bb988918aa8b23R3) [[2]](diffhunk://#diff-533b1a169348757840481dba5d0410305f939e43a62c534cf2bb988918aa8b23R29-R42)
* Modified the `run` method in `CommunityAnimalSeeder` to fetch and assign an `AnimalType` to the seeded `CommunityAnimal` instances. (`src/main/java/com/project/demo/logic/seeds/CommunityAnimalSeeder.java`) [[1]](diffhunk://#diff-533b1a169348757840481dba5d0410305f939e43a62c534cf2bb988918aa8b23R53-R55) [[2]](diffhunk://#diff-533b1a169348757840481dba5d0410305f939e43a62c534cf2bb988918aa8b23R67)

### REST API Implementation:
* Added `AnimalTypeRestController` to provide endpoints for fetching animal types. Includes support for paginated retrieval of all animal types and fetching a single animal type by ID, with appropriate logging and response handling. (`src/main/java/com/project/demo/rest/animal_type/AnimalTypeRestController.java`)