### PR TITLE
Add multipart announcement creation with image upload

### DIFF
--- a/src/main/java/com/project/demo/logic/entity/announcement/AnnouncementRepository.java
+++ b/src/main/java/com/project/demo/logic/entity/announcement/AnnouncementRepository.java
@@ -53,7 +53,6 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
      */
     Optional<Announcement> findByIdAndMunicipalities_Id(Long id, Long municipalityId);
 
-
     /**
      * Finds Announcement entities by municipality ID and optional filters for title and state ID.
      * @param municipalityId the ID of the municipality to filter by.

--- a/src/main/java/com/project/demo/rest/announcement/dto/CreateAnnouncementMultipartDTO.java
+++ b/src/main/java/com/project/demo/rest/announcement/dto/CreateAnnouncementMultipartDTO.java
@@ -1,0 +1,18 @@
+package com.project.demo.rest.announcement.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class CreateAnnouncementMultipartDTO {
+    private String title;
+    private String description;
+    private Long stateId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private MultipartFile file;
+}


### PR DESCRIPTION
This pull request introduces a new feature for creating announcements with image uploads and includes related updates to services, DTOs, and controllers. The most important changes focus on enabling multipart file uploads, integrating with the Imgur API for image hosting, and enhancing the announcement creation process.

### New Feature: Announcement Creation with Image Upload

* **Addition of `CreateAnnouncementMultipartDTO`**: A new DTO class, `CreateAnnouncementMultipartDTO`, was added to encapsulate metadata and image files for creating announcements. (`src/main/java/com/project/demo/rest/announcement/dto/CreateAnnouncementMultipartDTO.java`)
* **New endpoint for creating announcements**: A new `POST /my-municipality` endpoint was added to the `AnnouncementRestController`, allowing authenticated municipal admins to create announcements with image uploads. This includes validation for the image file and state ID, and integration with the `Tripo3DService` for image hosting. (`src/main/java/com/project/demo/rest/announcement/AnnouncementRestController.java`)

### Service Enhancements

* **Imgur API integration**: The `Tripo3DService` was updated with a new method, `uploadToImgur(MultipartFile file)`, to handle image uploads to Imgur. This method encodes the image in Base64, sends it to Imgur, and retrieves the public URL for the uploaded image. (`src/main/java/com/project/demo/service/model/Tripo3DService.java`)
* **Support for `MultipartFile`**: The `Tripo3DService` now imports and supports Spring's `MultipartFile` for handling file uploads. (`src/main/java/com/project/demo/service/model/Tripo3DService.java`)

### Minor Refactoring

* **Formatting of `@Autowired` fields**: The `AnnouncementRestController` was updated to improve readability by formatting `@Autowired` fields consistently. (`src/main/java/com/project/demo/rest/announcement/AnnouncementRestController.java`)
* **Removed unused blank line in `AnnouncementRepository`**: A minor cleanup was performed in `AnnouncementRepository` by removing an unnecessary blank line. (`src/main/java/com/project/demo/logic/entity/announcement/AnnouncementRepository.java`)Introduces a new endpoint for municipal admins to create announcements with image uploads using multipart/form-data. Adds CreateAnnouncementMultipartDTO for request data, integrates image upload to Imgur via Tripo3DService, and updates the controller to handle validation and persistence.