### PR TITLE
Send password reset email after admin user creation

### DIFF
--- a/src/main/java/com/project/demo/rest/admin/AdminController.java
+++ b/src/main/java/com/project/demo/rest/admin/AdminController.java
@@ -8,24 +8,25 @@ import com.project.demo.logic.entity.municipality.MunicipalityRepository;
 import com.project.demo.logic.entity.neighborhood.Neighborhood;
 import com.project.demo.logic.entity.neighborhood.NeighborhoodRepository;
 import com.project.demo.logic.entity.rol.Role;
-import com.project.demo.logic.entity.rol.RoleEnum;
 import com.project.demo.logic.entity.rol.RoleRepository;
+import com.project.demo.logic.entity.user.ForgotPasswordService;
 import com.project.demo.logic.entity.user.User;
 import com.project.demo.logic.entity.user.UserRepository;
 import com.project.demo.rest.auth.dto.RegisterUserRequestDTO;
+import com.project.demo.rest.municipality.MunicipalityRestController;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -50,6 +51,11 @@ public class AdminController {
 
     @Autowired
     private MunicipalityRepository municipalityRepository;
+
+    @Autowired
+    private ForgotPasswordService forgotPasswordService;
+
+    private final Logger logger = LoggerFactory.getLogger(AdminController.class);
 
     @PostMapping
     public ResponseEntity<?> createUser(@RequestBody RegisterUserRequestDTO dto, HttpServletRequest request) {
@@ -96,6 +102,13 @@ public class AdminController {
                 .build();
 
         userRepository.save(user);
+
+        try {
+            forgotPasswordService.resetPasswordAndSendEmail(dto.getEmail());
+            logger.info("Email sent to user created by admin: {}", dto.getEmail());
+        } catch (Exception e) {
+            logger.error("Error sending email to user created by admin: {}", e.getMessage());
+        }
 
         return new GlobalResponseHandler().handleResponse(
                 "Usuario creado exitosamente",

--- a/src/main/java/com/project/demo/rest/municipality/MunicipalityRestController.java
+++ b/src/main/java/com/project/demo/rest/municipality/MunicipalityRestController.java
@@ -50,6 +50,7 @@ public class MunicipalityRestController {
 
     @Autowired
     private MunicipalityStatusRepository municipalityStatusRepository;
+
     @Autowired
     private ForgotPasswordService forgotPasswordService;
 
@@ -177,8 +178,9 @@ public class MunicipalityRestController {
 
         try {
             forgotPasswordService.resetPasswordAndSendEmail(dto.getEmail());
+            logger.info("Email sent to admin user: {}", dto.getEmail());
         } catch (Exception e) {
-            logger.error("Error sending email to admin user: {}", e.getMessage());
+            logger.error("Error sending email to admin user municipality: {}", e.getMessage());
         }
 
         return new GlobalResponseHandler().handleResponse(

--- a/src/main/java/com/project/demo/rest/municipality/MunicipalityRestController.java
+++ b/src/main/java/com/project/demo/rest/municipality/MunicipalityRestController.java
@@ -9,6 +9,7 @@ import com.project.demo.logic.entity.municipality.*;
 import com.project.demo.logic.entity.rol.Role;
 import com.project.demo.logic.entity.rol.RoleEnum;
 import com.project.demo.logic.entity.rol.RoleRepository;
+import com.project.demo.logic.entity.user.ForgotPasswordService;
 import com.project.demo.logic.entity.user.User;
 import com.project.demo.logic.entity.user.UserRepository;
 import com.project.demo.rest.municipality.dto.*;
@@ -49,6 +50,8 @@ public class MunicipalityRestController {
 
     @Autowired
     private MunicipalityStatusRepository municipalityStatusRepository;
+    @Autowired
+    private ForgotPasswordService forgotPasswordService;
 
     private final Logger logger = LoggerFactory.getLogger(MunicipalityRestController.class);
 
@@ -171,6 +174,12 @@ public class MunicipalityRestController {
 
         adminUser.addRole(adminRole.get());
         userRepository.save(adminUser);
+
+        try {
+            forgotPasswordService.resetPasswordAndSendEmail(dto.getEmail());
+        } catch (Exception e) {
+            logger.error("Error sending email to admin user: {}", e.getMessage());
+        }
 
         return new GlobalResponseHandler().handleResponse(
                 "Municipality and admin user created successfully",


### PR DESCRIPTION
After creating a new municipality and its admin user, trigger a password reset email to the admin using ForgotPasswordService. This ensures the admin receives credentials securely. Added error handling and logging for email sending failures.


This pull request introduces functionality to reset an admin user's password and send an email upon the creation of a municipality. The changes primarily involve integrating the `ForgotPasswordService` into the `MunicipalityRestController`.

### Integration of ForgotPasswordService:

* [`src/main/java/com/project/demo/rest/municipality/MunicipalityRestController.java`](diffhunk://#diff-8f8e1bb50334536e748fc739019b77759555386d50245f992d0ac2752c01bb6eR12): Added an import for `ForgotPasswordService` and autowired it as a dependency in the controller. [[1]](diffhunk://#diff-8f8e1bb50334536e748fc739019b77759555386d50245f992d0ac2752c01bb6eR12) [[2]](diffhunk://#diff-8f8e1bb50334536e748fc739019b77759555386d50245f992d0ac2752c01bb6eR53-R54)
* [`src/main/java/com/project/demo/rest/municipality/MunicipalityRestController.java`](diffhunk://#diff-8f8e1bb50334536e748fc739019b77759555386d50245f992d0ac2752c01bb6eR178-R183): Updated the `create` method to invoke `forgotPasswordService.resetPasswordAndSendEmail` for sending a reset password email to the admin user. Includes error handling and logging for email-related exceptions.