### PR TITLE
Scrum 45 be dgutierrez

### DIFF
--- a/src/main/java/com/project/demo/rest/complaint/ComplaintRestController.java
+++ b/src/main/java/com/project/demo/rest/complaint/ComplaintRestController.java
@@ -369,9 +369,6 @@ public class ComplaintRestController {
         c.setComplaintState(cancel.get());
         complaintRepository.save(c);
 
-        // Opcional: notificar a admins
-        // notificationService.notifyComplaintCancelled(c);
-
         return wrapComplaintAsDto("Denuncia cancelada", c, HttpStatus.OK, req);
     }
 
@@ -548,9 +545,6 @@ public class ComplaintRestController {
              c.setObservations("Cerrada por la municipalidad tras inactividad del usuario.");
         }
         complaintRepository.save(c);
-
-        // opcional: notificar al denunciante que se cerró por inactividad si venía de WITH_OBSERVATIONS
-        // notificationService.notifyComplaintClosed(c);
 
         return wrapComplaintAsDto("Denuncia cerrada", c, HttpStatus.OK, req);
     }

--- a/src/main/java/com/project/demo/rest/complaint/ComplaintRestController.java
+++ b/src/main/java/com/project/demo/rest/complaint/ComplaintRestController.java
@@ -55,6 +55,7 @@ public class ComplaintRestController {
 
     /**
      * Filtra denuncias por tipo/estado dentro de la municipalidad del admin autenticado.
+     * @author dgutierrez
      */
     @GetMapping("/my-municipality/filter")
     @PreAuthorize("hasRole('MUNICIPAL_ADMIN')")
@@ -101,6 +102,7 @@ public class ComplaintRestController {
 
     /**
      * Obtiene una denuncia por ID si pertenece a la municipalidad del admin.
+     * @author dgutierrez
      */
     @GetMapping("/my-municipality/{id}")
     @PreAuthorize("hasRole('MUNICIPAL_ADMIN')")
@@ -131,6 +133,7 @@ public class ComplaintRestController {
 
     /**
      * Denuncias del usuario autenticado (opcionalmente filtradas).
+     * @author dgutierrez
      */
     @GetMapping("/my-complaints")
     @PreAuthorize("hasRole('COMMUNITY_USER')")
@@ -176,6 +179,7 @@ public class ComplaintRestController {
 
     /**
      * Obtiene una denuncia del usuario comunitario (propiedad obligatoria).
+     * @author dgutierrez
      */
     @GetMapping("/my-complaints/{id}")
     @PreAuthorize("hasRole('COMMUNITY_USER')")
@@ -207,6 +211,7 @@ public class ComplaintRestController {
 
     /**
      * Crea una denuncia (estado inicial: Abierta).
+     * @author dgutierrez
      */
     @PostMapping
     @PreAuthorize("hasAnyRole('COMMUNITY_USER')")
@@ -286,6 +291,7 @@ public class ComplaintRestController {
      * - Si está Abierta: solo actualiza campos.
      * - Si está Con observaciones: actualiza y pasa a Abierta (limpia observaciones).
      * - Otros estados: prohibido.
+     * @author dgutierrez
      */
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('COMMUNITY_USER')")
@@ -339,6 +345,8 @@ public class ComplaintRestController {
 
     /**
      * Cancela una denuncia del comunitario (solo si está Abierta).
+     * Solo el usuario comunitario que la creó puede cancelarla.
+     * @author dgutierrez
      */
     @PutMapping("/{id}/cancel")
     @PreAuthorize("hasRole('COMMUNITY_USER')")
@@ -373,7 +381,48 @@ public class ComplaintRestController {
     }
 
     /**
+     * Cancela una denuncia como administrador municipal.
+     * Puede cancelar en estado Abierta, Con observaciones o Aprobada.
+     * @author dgutierrez
+     */
+    @PutMapping("/{id}/cancel/admin")
+    @PreAuthorize("hasRole('MUNICIPAL_ADMIN')")
+    @Transactional
+    public ResponseEntity<?> cancelComplaintAsAdmin(@PathVariable Long id,
+                                                    @RequestHeader("Authorization") String authHeader,
+                                                    HttpServletRequest req) {
+        var handler = new GlobalResponseHandler();
+        var opt = complaintRepository.findById(id);
+        if (opt.isEmpty()) return handler.notFound("Denuncia no encontrada", req);
+
+        var c = opt.get();
+        if (isOutsideAdminMunicipality(c, authHeader)) {
+            return handler.badRequest("La denuncia no pertenece a su municipalidad", req);
+        }
+
+        var state = getComplaintStateEnumFromEntity(c);
+        if (!(state == ComplaintStateEnum.OPEN
+                || state == ComplaintStateEnum.WITH_OBSERVATIONS
+                || state == ComplaintStateEnum.APPROVED)) {
+            return handler.badRequest("Solo se puede cancelar una denuncia en estado Abierta, Con observaciones o Aprobada", req);
+        }
+
+        var cancel = complaintStateRepository.findByName(ComplaintStateEnum.CANCELLED.getName());
+        if (cancel.isEmpty()) return handler.internalError("Estado Cancelada no encontrado", req);
+
+        c.setComplaintState(cancel.get());
+        if (c.getObservations() == null || c.getObservations().isBlank()) {
+            c.setObservations("Cancelada por la municipalidad.");
+        }
+        complaintRepository.save(c);
+
+        return wrapComplaintAsDto("Denuncia cancelada por la municipalidad", c, HttpStatus.OK, req);
+    }
+
+    /**
      * Reenvía una denuncia que está Con observaciones → Abierta (atajo explícito).
+     * Solo el usuario comunitario que la creó puede reenviarla.
+     * @author dgutierrez
      */
     @PutMapping("/{id}/resubmit")
     @PreAuthorize("hasAnyRole('COMMUNITY_USER')")
@@ -414,6 +463,8 @@ public class ComplaintRestController {
 
     /**
      * Pasa a Con observaciones (o reescribe observaciones) desde Abierta/Con observaciones.
+     * Solo el admin municipal puede agregar observaciones.
+     * @author dgutierrez
      */
     @PutMapping("/{id}/observe")
     @PreAuthorize("hasAnyRole('MUNICIPAL_ADMIN')")
@@ -449,6 +500,8 @@ public class ComplaintRestController {
 
     /**
      * Aprueba una denuncia (solo si está Abierta).
+     * Solo el admin municipal puede aprobar denuncias.
+     * @author dgutierrez
      */
     @PutMapping("/{id}/approve")
     @PreAuthorize("hasAnyRole('MUNICIPAL_ADMIN')")
@@ -482,6 +535,8 @@ public class ComplaintRestController {
 
     /**
      * Completa una denuncia (solo si está Aprobada).
+     * Solo el admin municipal puede completar denuncias.
+     * @author dgutierrez
      */
     @PutMapping("/{id}/complete")
     @PreAuthorize("hasAnyRole('MUNICIPAL_ADMIN')")
@@ -516,6 +571,8 @@ public class ComplaintRestController {
     /**
      * Cierra una denuncia.
      * Permitido si está Completada o Con observaciones (caso de abandono por el usuario).
+     * Si está Abierta, se cierra con observaciones por defecto.
+     * @author dgutierrez
      */
     @PutMapping("/{id}/close")
     @PreAuthorize("hasRole('MUNICIPAL_ADMIN')")
@@ -533,19 +590,23 @@ public class ComplaintRestController {
         }
 
         var state = getComplaintStateEnumFromEntity(c);
-        if (!(state == ComplaintStateEnum.COMPLETED || state == ComplaintStateEnum.WITH_OBSERVATIONS)) {
-            return handler.badRequest("Solo se puede cerrar si la denuncia está Completada o Con observaciones", req);
+
+        if (state == ComplaintStateEnum.CANCELLED || state == ComplaintStateEnum.CLOSED) {
+            return handler.badRequest("La denuncia ya se encuentra en un estado terminal", req);
         }
 
         var closed = complaintStateRepository.findByName(ComplaintStateEnum.CLOSED.getName());
         if (closed.isEmpty()) return handler.internalError("Estado Cerrada no encontrado", req);
 
         c.setComplaintState(closed.get());
-         if (state == ComplaintStateEnum.WITH_OBSERVATIONS && (c.getObservations() == null || c.getObservations().isBlank())) {
-             c.setObservations("Cerrada por la municipalidad tras inactividad del usuario.");
-        }
-        complaintRepository.save(c);
 
+        // mensaje/observación por defecto si venía de WITH_OBSERVATIONS o OPEN
+        if ((state == ComplaintStateEnum.WITH_OBSERVATIONS || state == ComplaintStateEnum.OPEN)
+                && (c.getObservations() == null || c.getObservations().isBlank())) {
+            c.setObservations("Cerrada por la municipalidad.");
+        }
+
+        complaintRepository.save(c);
         return wrapComplaintAsDto("Denuncia cerrada", c, HttpStatus.OK, req);
     }
 
@@ -553,6 +614,12 @@ public class ComplaintRestController {
        HELPERS
        ============================================================ */
 
+    /**
+     * Obtiene el estado de la denuncia como ComplaintStateEnum a partir de la entidad Complaint.
+     * @param complaint
+     * @return
+     * @author dgutierrez
+     */
     private ComplaintStateEnum getComplaintStateEnumFromEntity(Complaint complaint) {
         return Arrays.stream(ComplaintStateEnum.values())
                 .filter(e -> e.getName().equalsIgnoreCase(complaint.getComplaintState().getName()))
@@ -560,12 +627,22 @@ public class ComplaintRestController {
                 .orElse(null);
     }
 
-    // Verifica si el estado es terminal (Cancelada o Cerrada)
+    /**
+     * Verifica si el estado es terminal (Cancelada o Cerrada)
+     * @param s
+     * @return
+     * @author dgutierrez
+     */
     private boolean isTerminal(ComplaintStateEnum s) {
         return s == ComplaintStateEnum.CANCELLED || s == ComplaintStateEnum.CLOSED;
     }
 
-    // Verifica si la denuncia no pertenece a la municipalidad del admin autenticado
+    /**
+     * Verifica si la denuncia está fuera de la municipalidad del admin autenticado.
+     * @param c Denuncia a verificar
+     * @param authHeader Header de autorización del admin
+     * @return true si está fuera, false si pertenece a su municipalidad
+     */
     private boolean isOutsideAdminMunicipality(Complaint c, String authHeader) {
         String email = jwtService.extractUsername(jwtService.getTokenFromHeader(authHeader));
         return userRepository.findByEmail(email)
@@ -574,7 +651,14 @@ public class ComplaintRestController {
                 .orElse(true);
     }
 
-    // Envuelve la respuesta con DTO y mensaje
+    /**
+     * Envuelve una denuncia como DTO y la retorna en una ResponseEntity.
+     * @param message Mensaje de éxito
+     * @param complaint Denuncia a envolver
+     * @param status Estado HTTP de la respuesta
+     * @param request Objeto HttpServletRequest para el manejo de la respuesta
+     * @return ResponseEntity con el DTO de la denuncia
+     */
     private ResponseEntity<?> wrapComplaintAsDto(String message, Complaint complaint, HttpStatus status, HttpServletRequest request) {
         ComplaintDTO dto = ComplaintDTO.fromEntity(complaint);
         return new GlobalResponseHandler().handleResponse(message, dto, status, request);

--- a/src/main/java/com/project/demo/rest/complaint/dto/UpdateComplaintMultipartDTO.java
+++ b/src/main/java/com/project/demo/rest/complaint/dto/UpdateComplaintMultipartDTO.java
@@ -2,6 +2,18 @@ package com.project.demo.rest.complaint.dto;
 
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * Data Transfer Object (DTO) for updating a complaint with multipart file upload.
+ * This DTO is used to encapsulate the data required for updating a complaint,
+ * including the description, geographical coordinates, complaint type ID, and an image file.
+ *
+ * @param description   the description of the complaint
+ * @param latitude      the latitude of the complaint location
+ * @param longitude     the longitude of the complaint location
+ * @param complaintTypeId the ID of the complaint type
+ * @param image         the image file associated with the complaint
+ * @author dgutierrez
+ */
 public record UpdateComplaintMultipartDTO(
         String description,
         Double latitude,


### PR DESCRIPTION
This pull request mainly adds or improves documentation and JavaDoc comments throughout the `ComplaintRestController` and related DTOs to clarify method purposes, expected behaviors, and authorship. It also introduces a new endpoint for municipal admins to cancel complaints and refines the logic for closing complaints, ensuring default messages are set appropriately based on complaint state.

Key changes include:

### Documentation improvements

* Added or enhanced JavaDoc comments for nearly all controller methods in `ComplaintRestController`, specifying the author and clarifying method responsibilities. [[1]](diffhunk://#diff-88e90d6953f4705ddc5147a10566b7548e138701b797b05748288a75913eefffR58) [[2]](diffhunk://#diff-88e90d6953f4705ddc5147a10566b7548e138701b797b05748288a75913eefffR105) [[3]](diffhunk://#diff-88e90d6953f4705ddc5147a10566b7548e138701b797b05748288a75913eefffR136) [[4]](diffhunk://#diff-88e90d6953f4705ddc5147a10566b7548e138701b797b05748288a75913eefffR182) [[5]](diffhunk://#diff-88e90d6953f4705ddc5147a10566b7548e138701b797b05748288a75913eefffR214) [[6]](diffhunk://#diff-88e90d6953f4705ddc5147a10566b7548e138701b797b05748288a75913eefffR294) [[7]](diffhunk://#diff-88e90d6953f4705ddc5147a10566b7548e138701b797b05748288a75913eefffR348-R349) [[8]](diffhunk://#diff-88e90d6953f4705ddc5147a10566b7548e138701b797b05748288a75913eefffR466-R467) [[9]](diffhunk://#diff-88e90d6953f4705ddc5147a10566b7548e138701b797b05748288a75913eefffR503-R504) [[10]](diffhunk://#diff-88e90d6953f4705ddc5147a10566b7548e138701b797b05748288a75913eefffR538-R539) [[11]](diffhunk://#diff-88e90d6953f4705ddc5147a10566b7548e138701b797b05748288a75913eefffR574-R575)
* Improved and extended JavaDoc for helper methods, such as `getComplaintStateEnumFromEntity`, `isTerminal`, `isOutsideAdminMunicipality`, and `wrapComplaintAsDto`, to clarify their purpose and usage. [[1]](diffhunk://#diff-88e90d6953f4705ddc5147a10566b7548e138701b797b05748288a75913eefffL539-R645) [[2]](diffhunk://#diff-88e90d6953f4705ddc5147a10566b7548e138701b797b05748288a75913eefffL583-R661)
* Added a comprehensive JavaDoc comment to the `UpdateComplaintMultipartDTO` record, describing its fields and usage.

### New functionality

* Added a new endpoint `/my-municipality/{id}/cancel/admin` that allows municipal admins to cancel complaints in the OPEN, WITH_OBSERVATIONS, or APPROVED states, including appropriate validation and default observation handling.

### Complaint closing logic

* Refined the logic for closing complaints: now, if a complaint is in the OPEN or WITH_OBSERVATIONS state and lacks observations, a default message ("Cerrada por la municipalidad.") is set. Also, prevents closing complaints already in a terminal state (CANCELLED or CLOSED).

These changes improve code clarity, maintainability, and ensure that complaint state transitions and permissions are more robustly enforced.